### PR TITLE
feat: NOMS compliance and cryptoHashOff bugfix

### DIFF
--- a/example/debug_noms.dart
+++ b/example/debug_noms.dart
@@ -1,0 +1,11 @@
+import 'package:nanodart/nanodart.dart';
+
+void main() {
+  String seed = '681FD5ED71A9F81E9D29E3450F6CD8AACB87346FD21A26003389290B9D0CB173';
+  String privKey = NanoKeys.seedToPrivate(seed, 0);
+  print('Private Key (Seed Index 0): ' + privKey);
+  
+  String pk = NanoKeys.createPublicKey(privKey);
+  print('Public Key for Private Key: ' + pk);
+  print('Address for Public Key: ' + NanoAccounts.createAccount(NanoAccountType.NANO, pk));
+}

--- a/lib/src/crypto/tweetnacl_blake2b.dart
+++ b/lib/src/crypto/tweetnacl_blake2b.dart
@@ -1569,12 +1569,8 @@ class TweetNaclFast {
   // TBD 64bits of n
   ///int cryptoHash(Uint8List out, Uint8List m, long n)
   static int cryptoHashOff(Uint8List out, Uint8List m, final int moff, int n) {
-    Uint8List input = Uint8List(n);
-    for (int i = 0; i < n; ++i) {
-      input[i] = m[i];
-    }
-    Blake2bDigest blake2b = Blake2bDigest(digestSize: n);
-    blake2b.update(input, 0, input.length);
+    Blake2bDigest blake2b = Blake2bDigest(digestSize: out.length);
+    blake2b.update(m, 0, n);
     blake2b.doFinal(out, moff);
 
     return 0;

--- a/lib/src/signing/signer.dart
+++ b/lib/src/signing/signer.dart
@@ -10,6 +10,17 @@ class NanoSignatures {
         .toUpperCase();
   }
 
+  static String getMessageDigest(String message) {
+    Uint8List header =
+        NanoHelpers.stringToBytesUtf8('\x18Nano Off-chain Message:\n');
+    Uint8List messageBytes = NanoHelpers.stringToBytesUtf8(message);
+    Uint8List lengthBytes = NanoHelpers.intToBytes(messageBytes.length, 4);
+
+    Uint8List payloadHash =
+        Blake2b.digest256([header, lengthBytes, messageBytes]);
+    return NanoHelpers.byteToHex(payloadHash).toUpperCase();
+  }
+
   /// Sign a message according to NOMS (Nano Off-chain Message Signing) standard (ORIS-001)
   static String signMessage(String message, String privKey) {
     Uint8List header =

--- a/lib/src/signing/signer.dart
+++ b/lib/src/signing/signer.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+import 'package:nanodart/src/crypto/blake2b.dart';
 import 'package:nanodart/src/crypto/tweetnacl_blake2b.dart';
 import 'package:nanodart/src/util.dart';
 
@@ -6,5 +8,37 @@ class NanoSignatures {
     return NanoHelpers.byteToHex(Signature.detached(
             NanoHelpers.hexToBytes(hash), NanoHelpers.hexToBytes(privKey)))
         .toUpperCase();
+  }
+
+  /// Sign a message according to NOMS (Nano Off-chain Message Signing) standard (ORIS-001)
+  static String signMessage(String message, String privKey) {
+    Uint8List header =
+        NanoHelpers.stringToBytesUtf8('\x18Nano Off-chain Message:\n');
+    Uint8List messageBytes = NanoHelpers.stringToBytesUtf8(message);
+    Uint8List lengthBytes = NanoHelpers.intToBytes(messageBytes.length, 4);
+
+    Uint8List payloadHash =
+        Blake2b.digest256([header, lengthBytes, messageBytes]);
+
+    return NanoHelpers.byteToHex(Signature.detached(
+            payloadHash, NanoHelpers.hexToBytes(privKey)))
+        .toUpperCase();
+  }
+
+  /// Verify a message signature according to NOMS (Nano Off-chain Message Signing) standard (ORIS-001)
+  static bool verifyMessage(
+      String message, String signature, String publicKey) {
+    Uint8List header =
+        NanoHelpers.stringToBytesUtf8('\x18Nano Off-chain Message:\n');
+    Uint8List messageBytes = NanoHelpers.stringToBytesUtf8(message);
+    Uint8List lengthBytes = NanoHelpers.intToBytes(messageBytes.length, 4);
+
+    Uint8List payloadHash =
+        Blake2b.digest256([header, lengthBytes, messageBytes]);
+
+    return Signature.detachedVerify(
+        payloadHash,
+        NanoHelpers.hexToBytes(signature),
+        NanoHelpers.hexToBytes(publicKey));
   }
 }

--- a/test/nanodart_test.dart
+++ b/test/nanodart_test.dart
@@ -220,5 +220,35 @@ void main() {
       expect(NanoSignatures.verifyMessage(message + '!', signature, publicKey),
           false);
     });
+
+    test('test NOMS message signing and verification with empty message', () {
+      String privKey =
+          '67EDBC8F904091738DF33B4B6917261DB91DD9002D3985A7BA090345264A46C6';
+      String publicKey = NanoKeys.createPublicKey(privKey);
+      String message = '';
+
+      // Sign
+      String signature = NanoSignatures.signMessage(message, privKey);
+      expect(signature,
+          '06ABEFD232DEF6238AB88ADA8EF6500BE81C8C516D4C34D61273F2DAE706339611F2E58570575AE6DAA43381FC479615D23690FFBE26F678579D8779735F7D0B');
+
+      // Verify
+      expect(NanoSignatures.verifyMessage(message, signature, publicKey), true);
+    });
+
+    test('test NOMS verification with OWS-generated signature (dogfooding)', () {
+      String address =
+          "nano_1hfrig58wzrg4pzqen17cyannpy1173oi7jz7zd6srjsqjh7ozcgec9uyo9n";
+      String message = "I am me.";
+      String signature =
+          "3de8620fb30967916d3dc36cd09eba9a633d1678b986fbc31b70ae2834db25a898085bbce32b744aef42ed56b5c001ffebd5516e78c9f22c678dde2d8bdc150a";
+
+      String publicKey = NanoAccounts.extractPublicKey(address);
+      expect(publicKey.toUpperCase(),
+          '3DB883866E7F0E15BF76500557914A5BC0014358163F2FD64CE239BC5E5AFD4E');
+
+      // Verify
+      expect(NanoSignatures.verifyMessage(message, signature, publicKey), true);
+    });
   });
 }

--- a/test/nanodart_test.dart
+++ b/test/nanodart_test.dart
@@ -167,15 +167,58 @@ void main() {
           false);
     });
 
-    test('test NOMS known vector from another implementation', () {
-      String message = 'Hej!';
-      String account =
-          'nano_1hfrig58wzrg4pzqen17cyannpy1173oi7jz7zd6srjsqjh7ozcgec9uyo9n';
-      String signature =
-          '51953e3bd9c20fd648445e6aea18a01abfe378cebfd795fc61a37ffe24f1821d6eadb78863d65e978fcd1dd323ad0628bff9b74778c0c4ef2b6efb34479b020f';
+    test('test NOMS message signing and verification with known vector', () {
+      // Known vector provided by user
+      String privKey =
+          '681FD5ED71A9F81E9D29E3450F6CD8AACB87346FD21A26003389290B9D0CB173';
+      String expectedPublicKey =
+          'D2B3C9D00FFB55E84E7979D67308A515FB07CA79E40A77EB1AAFE62881781783';
+      String expectedAddress =
+          'nano_3noms9a1zytox399kygpge6cc7hu1z79ms1cgzojodz8741qi7w5u3nzb8mn';
+      String message = 'Hej Nano!🥦';
+      String expectedSignature =
+          '535C745819D0F40056F3C46402B4FAE4356B3A8897BDE99C955D411920E740D781E6DDDCBDE228E8B86C4383A1003F9F315519FF73BD356F561D19865DC90F09';
 
-      String publicKey = NanoAccounts.extractPublicKey(account);
+      // Verify key derivation
+      String publicKey = NanoKeys.createPublicKey(privKey);
+      expect(publicKey.toUpperCase(), expectedPublicKey.toUpperCase());
+
+      // Verify address generation
+      String address =
+          NanoAccounts.createAccount(NanoAccountType.NANO, publicKey);
+      expect(address, expectedAddress);
+
+      // Verify signing
+      String signature = NanoSignatures.signMessage(message, privKey);
+      expect(signature.toUpperCase(), expectedSignature.toUpperCase());
+
+      // Verify verification
       expect(NanoSignatures.verifyMessage(message, signature, publicKey), true);
+    });
+
+    test('test NOMS message signing and verification with library-generated key',
+        () {
+      // Path 2: Library-generated key
+      String seed = NanoSeeds.generateSeed();
+      String privKey = NanoKeys.seedToPrivate(seed, 0);
+      String publicKey = NanoKeys.createPublicKey(privKey);
+      String address =
+          NanoAccounts.createAccount(NanoAccountType.NANO, publicKey);
+      String message = 'Test message for library-generated key 🚀';
+
+      // Sign
+      String signature = NanoSignatures.signMessage(message, privKey);
+
+      // Verify
+      expect(NanoSignatures.verifyMessage(message, signature, publicKey), true);
+
+      // Verify address matches the public key
+      expect(NanoAccounts.createAccount(NanoAccountType.NANO, publicKey),
+          address);
+
+      // Negative test: wrong message
+      expect(NanoSignatures.verifyMessage(message + '!', signature, publicKey),
+          false);
     });
   });
 }

--- a/test/nanodart_test.dart
+++ b/test/nanodart_test.dart
@@ -136,5 +136,46 @@ void main() {
       Uint8List decrypted = NanoCrypt.decrypt(encrypted, password);
       expect(NanoHelpers.byteToHex(decrypted), NanoHelpers.byteToHex(seed));
     });
+
+    test('test NOMS message signing and verification', () {
+      String privKey =
+          '67EDBC8F904091738DF33B4B6917261DB91DD9002D3985A7BA090345264A46C6';
+      String publicKey = NanoKeys.createPublicKey(privKey);
+      String message = 'Hello Nano!';
+
+      String signature = NanoSignatures.signMessage(message, privKey);
+
+      // Verify correct signature
+      expect(NanoSignatures.verifyMessage(message, signature, publicKey), true);
+
+      // Verify failure with wrong message
+      expect(
+          NanoSignatures.verifyMessage('Hello Nano?', signature, publicKey),
+          false);
+
+      // Verify failure with wrong signature
+      String invalidSignature = signature.replaceFirst('A', 'B');
+      expect(
+          NanoSignatures.verifyMessage(message, invalidSignature, publicKey),
+          false);
+
+      // Verify failure with wrong public key
+      String otherPrivKey =
+          '22EDDBF0D72E9A4232C3FE6689A6CB0A228C9ED822715A63E2F8644AA2C905A4';
+      String otherPublicKey = NanoKeys.createPublicKey(otherPrivKey);
+      expect(NanoSignatures.verifyMessage(message, signature, otherPublicKey),
+          false);
+    });
+
+    test('test NOMS known vector from another implementation', () {
+      String message = 'Hej!';
+      String account =
+          'nano_1hfrig58wzrg4pzqen17cyannpy1173oi7jz7zd6srjsqjh7ozcgec9uyo9n';
+      String signature =
+          '51953e3bd9c20fd648445e6aea18a01abfe378cebfd795fc61a37ffe24f1821d6eadb78863d65e978fcd1dd323ad0628bff9b74778c0c4ef2b6efb34479b020f';
+
+      String publicKey = NanoAccounts.extractPublicKey(account);
+      expect(NanoSignatures.verifyMessage(message, signature, publicKey), true);
+    });
   });
 }


### PR DESCRIPTION
## Description
This PR implements **Nano Off-chain Message Signing (NOMS)** ([ORIS-001](https://github.com/OpenRai/Standards/blob/main/rfcs/ORIS-001.md)) for message signing and verification, _and_ resolves a critical bug in the underlying cryptographic hashing logic.

### Key Changes
- **NOMS Compliance**: Added `signMessage` and `verifyMessage` to `NanoSignatures`. These methods handle magic headers, length encoding, and Blake2b-256 hashing as per spec.
- **Bug Fix**: Corrected `TweetNaclFast.cryptoHashOff` to use the _output_ buffer's length as the `digestSize`. Previously, it used the _input_ length, which caused verification to fail for messages where the payload exceeded 64 bytes.
- **Testing**: Added a comprehensive test suite for NOMS, including a known-vector test.

### Rationale for Combined PR
The `cryptoHashOff` bug was discovered during the implementation of NOMS. Since this bug directly prevented NOMS verification in turn from functioning for standard payloads, inclusion of the fix here was a strict prerequisite for the feature. Since the update frequency of this library seems quite low, as was probably the usefulness of the old "sign" and "verify" feature as exposed by Cake Wallet, I reasoned it make more sense to just fix it in one go, so that I can follow up with a corresponding PR in the other project.
